### PR TITLE
Ability to provide query string params to DELETE

### DIFF
--- a/client.go
+++ b/client.go
@@ -238,24 +238,17 @@ func (c *Client) Delete(endpoint string) (*Response, error) {
 	})
 }
 
-// DeleteP executes DELETE request to the endpoint with optional query arguments
+// DeleteWithParams executes DELETE request to the endpoint with optional query arguments
 //
-// re, err := c.Delete(c.Endpoint("users", "id1"), url.Values{"force": []string{"true"}})
+// re, err := c.DeleteWithParams(c.Endpoint("users", "id1"), url.Values{"force": []string{"true"}})
 //
-func (c *Client) DeleteP(endpoint string, params url.Values) (*Response, error) {
+func (c *Client) DeleteWithParams(endpoint string, params url.Values) (*Response, error) {
 	baseURL, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
 	}
 	baseURL.RawQuery = params.Encode()
-	return c.RoundTrip(func() (*http.Response, error) {
-		req, err := http.NewRequest("DELETE", baseURL.String(), nil)
-		if err != nil {
-			return nil, err
-		}
-		c.addAuth(req)
-		return c.client.Do(req)
-	})
+	return c.Delete(baseURL.String())
 }
 
 // Get executes GET request to the server endpoint with optional query arguments passed in params

--- a/client.go
+++ b/client.go
@@ -223,11 +223,26 @@ func (c *Client) PutJSON(endpoint string, data interface{}) (*Response, error) {
 	})
 }
 
-// Delete executes DELETE request to the endpoint with optional query arguments
+// Delete executes DELETE request to the endpoint with no body
 //
 // re, err := c.Delete(c.Endpoint("users", "id1"), url.Values{"force": []string{"true"}})
 //
-func (c *Client) Delete(endpoint string, params url.Values) (*Response, error) {
+func (c *Client) Delete(endpoint string) (*Response, error) {
+	return c.RoundTrip(func() (*http.Response, error) {
+		req, err := http.NewRequest("DELETE", endpoint, nil)
+		if err != nil {
+			return nil, err
+		}
+		c.addAuth(req)
+		return c.client.Do(req)
+	})
+}
+
+// DeleteP executes DELETE request to the endpoint with optional query arguments
+//
+// re, err := c.Delete(c.Endpoint("users", "id1"), url.Values{"force": []string{"true"}})
+//
+func (c *Client) DeleteP(endpoint string, params url.Values) (*Response, error) {
 	baseURL, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err

--- a/client.go
+++ b/client.go
@@ -225,7 +225,7 @@ func (c *Client) PutJSON(endpoint string, data interface{}) (*Response, error) {
 
 // Delete executes DELETE request to the endpoint with no body
 //
-// re, err := c.Delete(c.Endpoint("users", "id1"), url.Values{"force": []string{"true"}})
+// re, err := c.Delete(c.Endpoint("users", "id1"))
 //
 func (c *Client) Delete(endpoint string) (*Response, error) {
 	return c.RoundTrip(func() (*http.Response, error) {

--- a/client.go
+++ b/client.go
@@ -223,13 +223,18 @@ func (c *Client) PutJSON(endpoint string, data interface{}) (*Response, error) {
 	})
 }
 
-// Delete executes DELETE request to the endpoint with no body
+// Delete executes DELETE request to the endpoint with optional query arguments
 //
-// re, err := c.Delete(c.Endpoint("users", "id1"))
+// re, err := c.Delete(c.Endpoint("users", "id1"), url.Values{"force": []string{"true"}})
 //
-func (c *Client) Delete(endpoint string) (*Response, error) {
+func (c *Client) Delete(endpoint string, params url.Values) (*Response, error) {
+	baseURL, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	baseURL.RawQuery = params.Encode()
 	return c.RoundTrip(func() (*http.Response, error) {
-		req, err := http.NewRequest("DELETE", endpoint, nil)
+		req, err := http.NewRequest("DELETE", baseURL.String(), nil)
 		if err != nil {
 			return nil, err
 		}

--- a/client_test.go
+++ b/client_test.go
@@ -128,19 +128,23 @@ func (s *ClientSuite) TestDelete(c *C) {
 	var method string
 	var user, pass string
 	var ok bool
+	var query url.Values
 	srv := serveHandler(func(w http.ResponseWriter, r *http.Request) {
 		user, pass, ok = r.BasicAuth()
 		method = r.Method
+		query = r.URL.Query()
 	})
 	defer srv.Close()
 
 	clt := newC(srv.URL, "v1", BasicAuth("user", "pass"))
-	re, err := clt.Delete(clt.Endpoint("a", "b"))
+	values := url.Values{"force": []string{"true"}}
+	re, err := clt.Delete(clt.Endpoint("a", "b"), values)
 	c.Assert(err, IsNil)
 	c.Assert(method, Equals, "DELETE")
 	c.Assert(re.Code(), Equals, http.StatusOK)
 	c.Assert(user, DeepEquals, "user")
 	c.Assert(pass, DeepEquals, "pass")
+	c.Assert(query, DeepEquals, values)
 }
 
 func (s *ClientSuite) TestGet(c *C) {

--- a/client_test.go
+++ b/client_test.go
@@ -128,6 +128,25 @@ func (s *ClientSuite) TestDelete(c *C) {
 	var method string
 	var user, pass string
 	var ok bool
+	srv := serveHandler(func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok = r.BasicAuth()
+		method = r.Method
+	})
+	defer srv.Close()
+
+	clt := newC(srv.URL, "v1", BasicAuth("user", "pass"))
+	re, err := clt.Delete(clt.Endpoint("a", "b"))
+	c.Assert(err, IsNil)
+	c.Assert(method, Equals, "DELETE")
+	c.Assert(re.Code(), Equals, http.StatusOK)
+	c.Assert(user, DeepEquals, "user")
+	c.Assert(pass, DeepEquals, "pass")
+}
+
+func (s *ClientSuite) TestDeleteP(c *C) {
+	var method string
+	var user, pass string
+	var ok bool
 	var query url.Values
 	srv := serveHandler(func(w http.ResponseWriter, r *http.Request) {
 		user, pass, ok = r.BasicAuth()
@@ -138,7 +157,7 @@ func (s *ClientSuite) TestDelete(c *C) {
 
 	clt := newC(srv.URL, "v1", BasicAuth("user", "pass"))
 	values := url.Values{"force": []string{"true"}}
-	re, err := clt.Delete(clt.Endpoint("a", "b"), values)
+	re, err := clt.DeleteP(clt.Endpoint("a", "b"), values)
 	c.Assert(err, IsNil)
 	c.Assert(method, Equals, "DELETE")
 	c.Assert(re.Code(), Equals, http.StatusOK)

--- a/client_test.go
+++ b/client_test.go
@@ -127,9 +127,8 @@ func (s *ClientSuite) TestPostJSON(c *C) {
 func (s *ClientSuite) TestDelete(c *C) {
 	var method string
 	var user, pass string
-	var ok bool
 	srv := serveHandler(func(w http.ResponseWriter, r *http.Request) {
-		user, pass, ok = r.BasicAuth()
+		user, pass, _ = r.BasicAuth()
 		method = r.Method
 	})
 	defer srv.Close()
@@ -146,10 +145,9 @@ func (s *ClientSuite) TestDelete(c *C) {
 func (s *ClientSuite) TestDeleteP(c *C) {
 	var method string
 	var user, pass string
-	var ok bool
 	var query url.Values
 	srv := serveHandler(func(w http.ResponseWriter, r *http.Request) {
-		user, pass, ok = r.BasicAuth()
+		user, pass, _ = r.BasicAuth()
 		method = r.Method
 		query = r.URL.Query()
 	})
@@ -157,7 +155,7 @@ func (s *ClientSuite) TestDeleteP(c *C) {
 
 	clt := newC(srv.URL, "v1", BasicAuth("user", "pass"))
 	values := url.Values{"force": []string{"true"}}
-	re, err := clt.DeleteP(clt.Endpoint("a", "b"), values)
+	re, err := clt.DeleteWithParams(clt.Endpoint("a", "b"), values)
 	c.Assert(err, IsNil)
 	c.Assert(method, Equals, "DELETE")
 	c.Assert(re.Code(), Equals, http.StatusOK)


### PR DESCRIPTION
Note: I added a new method `DeleteP` instead of modifying the original `Delete` method because a lot of stuff depends on it, e.g. teleport.