### PR TITLE
Allow empty version

### DIFF
--- a/client.go
+++ b/client.go
@@ -133,7 +133,11 @@ func (c *Client) HTTPClient() *http.Client {
 // c.Endpoint("user", "john") // returns "/v1/users/john"
 //
 func (c *Client) Endpoint(params ...string) string {
-	return fmt.Sprintf("%s/%s/%s", c.addr, c.v, strings.Join(params, "/"))
+	if c.v != "" {
+		return fmt.Sprintf("%s/%s/%s", c.addr, c.v, strings.Join(params, "/"))
+	} else {
+		return fmt.Sprintf("%s/%s", c.addr, strings.Join(params, "/"))
+	}
 }
 
 // PostForm posts urlencoded form with values and returns the result

--- a/client.go
+++ b/client.go
@@ -135,9 +135,8 @@ func (c *Client) HTTPClient() *http.Client {
 func (c *Client) Endpoint(params ...string) string {
 	if c.v != "" {
 		return fmt.Sprintf("%s/%s/%s", c.addr, c.v, strings.Join(params, "/"))
-	} else {
-		return fmt.Sprintf("%s/%s", c.addr, strings.Join(params, "/"))
 	}
+	return fmt.Sprintf("%s/%s", c.addr, strings.Join(params, "/"))
 }
 
 // PostForm posts urlencoded form with values and returns the result

--- a/client_test.go
+++ b/client_test.go
@@ -425,6 +425,13 @@ func (s *ClientSuite) TestCookies(c *C) {
 	c.Assert(re.Cookies()[0].Value, DeepEquals, responseCookies[0].Value)
 }
 
+func (s *ClientSuite) TestEndpoint(c *C) {
+	client := newC("http://localhost", "v1")
+	c.Assert(client.Endpoint("api", "resource"), Equals, "http://localhost/v1/api/resource")
+	client = newC("http://localhost", "")
+	c.Assert(client.Endpoint("api", "resource"), Equals, "http://localhost/api/resource")
+}
+
 func newC(addr, version string, params ...ClientParam) *testClient {
 	c, err := NewClient(addr, version, params...)
 	if err != nil {


### PR DESCRIPTION
Not all APIs follow our versioning scheme `/v1/api/blah` so it makes sense to build correct URLs in case of empty versions so roundtrip client can be used with other APIs.