### PR TITLE
Use io.Pipe in PostForm to avoid reading whole files into memory

### DIFF
--- a/client.go
+++ b/client.go
@@ -522,7 +522,7 @@ func writeForm(writer *multipart.Writer, vals url.Values, files ...fileBuffer) e
 }
 
 // newBuffersFromFiles wraps the specified files with a reader
-// that caches the data it receives into a memory buffer
+// that caches data into a memory buffer
 func newBuffersFromFiles(files []File) []fileBuffer {
 	buffers := make([]fileBuffer, 0, len(files))
 	for _, file := range files {
@@ -531,7 +531,7 @@ func newBuffersFromFiles(files []File) []fileBuffer {
 	return buffers
 }
 
-// newFileBuffer creates a buffer for reading from the specified File f
+// newFileBuffer creates a buffer for reading from the specified File file
 func newFileBuffer(file File) fileBuffer {
 	buf := &bytes.Buffer{}
 	return fileBuffer{
@@ -576,8 +576,8 @@ func (r *limitWriter) Write(p []byte) (n int, err error) {
 	return n, err
 }
 
-// limitWriter reads upto maxBytes bytes from the specified stream and returns errShortWrite
-// if more than n bytes are written
+// limitWriter is an io.Writer that aborts with errShortWrite
+// if more than maxBytes bytes are written
 type limitWriter struct {
 	io.Writer
 	maxBytes int64

--- a/client_test.go
+++ b/client_test.go
@@ -481,6 +481,18 @@ func (s *ClientSuite) TestEndpoint(c *C) {
 	c.Assert(client.Endpoint("api", "resource"), Equals, "http://localhost/api/resource")
 }
 
+func (s *ClientSuite) TestLimitsWrites(c *C) {
+	var buf bytes.Buffer
+	w := &limitWriter{&buf, 10}
+	input := []byte("The quick brown fox jumps over the lazy dog")
+	r := bytes.NewReader(input)
+	_, err := io.Copy(w, r)
+	c.Assert(err, Equals, errShortWrite)
+	c.Assert(buf.Bytes(), DeepEquals, input[:10])
+	out, err := ioutil.ReadAll(r)
+	c.Assert(out, DeepEquals, input[10:], Commentf("expected %q but got %q", input[10:], out))
+}
+
 func newC(addr, version string, params ...ClientParam) *testClient {
 	c, err := NewClient(addr, version, params...)
 	if err != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -342,7 +342,7 @@ func (s *ClientSuite) TestPostMultipartForm(c *C) {
 }
 
 func (s *ClientSuite) TestPostMultipartFormLargeFile(c *C) {
-	buffer := make([]byte, 100<<10)
+	buffer := make([]byte, 1024<<10)
 	rand.Read(buffer)
 	files := []File{
 		File{

--- a/client_test.go
+++ b/client_test.go
@@ -51,7 +51,9 @@ func (s *ClientSuite) TestPostForm(c *C) {
 	var method string
 	var user, pass string
 	srv := serveHandler(func(w http.ResponseWriter, r *http.Request) {
-		user, pass, _ = r.BasicAuth()
+		var ok bool
+		user, pass, ok = r.BasicAuth()
+		c.Assert(ok, Equals, true)
 		u = r.URL
 		c.Assert(r.ParseForm(), IsNil)
 		form = r.Form

--- a/client_test.go
+++ b/client_test.go
@@ -50,9 +50,8 @@ func (s *ClientSuite) TestPostForm(c *C) {
 	var form url.Values
 	var method string
 	var user, pass string
-	var ok bool
 	srv := serveHandler(func(w http.ResponseWriter, r *http.Request) {
-		user, pass, ok = r.BasicAuth()
+		user, pass, _ = r.BasicAuth()
 		u = r.URL
 		c.Assert(r.ParseForm(), IsNil)
 		form = r.Form
@@ -76,9 +75,10 @@ func (s *ClientSuite) TestPostForm(c *C) {
 
 func (s *ClientSuite) TestAddAuth(c *C) {
 	var user, pass string
-	var ok bool
 	srv := serveHandler(func(w http.ResponseWriter, r *http.Request) {
+		var ok bool
 		user, pass, ok = r.BasicAuth()
+		c.Assert(ok, Equals, true)
 		io.WriteString(w, "hello back")
 	})
 	defer srv.Close()
@@ -97,11 +97,12 @@ func (s *ClientSuite) TestAddAuth(c *C) {
 func (s *ClientSuite) TestPostJSON(c *C) {
 	var data interface{}
 	var user, pass string
-	var ok bool
 	var method string
 	srv := serveHandler(func(w http.ResponseWriter, r *http.Request) {
+		var ok bool
 		method = r.Method
 		user, pass, ok = r.BasicAuth()
+		c.Assert(ok, Equals, true)
 		err := json.NewDecoder(r.Body).Decode(&data)
 		c.Assert(err, IsNil)
 	})
@@ -203,9 +204,10 @@ func (s *ClientSuite) TestGetFile(c *C) {
 	err := ioutil.WriteFile(fileName, []byte("hello there"), 0666)
 	c.Assert(err, IsNil)
 	var user, pass string
-	var ok bool
 	srv := serveHandler(func(w http.ResponseWriter, r *http.Request) {
+		var ok bool
 		user, pass, ok = r.BasicAuth()
+		c.Assert(ok, Equals, true)
 		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename=%v`, "file.txt"))
 		http.ServeFile(w, r, fileName)
 	})
@@ -262,10 +264,11 @@ func (s *ClientSuite) TestOpenFile(c *C) {
 	defer os.RemoveAll(file.Name())
 
 	now := time.Now().UTC()
-	var ok bool
 	var user, pass string
 	srv := serveHandler(func(w http.ResponseWriter, r *http.Request) {
+		var ok bool
 		user, pass, ok = r.BasicAuth()
+		c.Assert(ok, Equals, true)
 		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename=%v`, file.Name()))
 		http.ServeContent(w, r, file.Name(), now, file)
 	})
@@ -371,9 +374,10 @@ func (s *ClientSuite) testPostMultipartForm(c *C, files []File, expected [][]byt
 	var method string
 	var data [][]byte
 	var user, pass string
-	var ok bool
 	srv := serveHandler(func(w http.ResponseWriter, r *http.Request) {
+		var ok bool
 		user, pass, ok = r.BasicAuth()
+		c.Assert(ok, Equals, true)
 		u = r.URL
 		c.Assert(r.ParseMultipartForm(64<<20), IsNil)
 		params = r.Form
@@ -418,9 +422,10 @@ func (s *ClientSuite) testPostMultipartForm(c *C, files []File, expected [][]byt
 
 func (s *ClientSuite) TestGetBasicAuth(c *C) {
 	var user, pass string
-	var ok bool
 	srv := serveHandler(func(w http.ResponseWriter, r *http.Request) {
+		var ok bool
 		user, pass, ok = r.BasicAuth()
+		c.Assert(ok, Equals, true)
 	})
 	defer srv.Close()
 


### PR DESCRIPTION
Implement PostFrom in terms of `io.Pipe`. This will be beneficial for uploading large(r) files.