### PR TITLE
Validate all URL paths.

### DIFF
--- a/client.go
+++ b/client.go
@@ -93,6 +93,15 @@ func CookieJar(jar http.CookieJar) ClientParam {
 	}
 }
 
+// SanitizerEnabled will enable the input sanitizer which passes the URL
+// path through a strict whitelist.
+func SanitizerEnabled(sanitizerEnabled bool) ClientParam {
+	return func(c *Client) error {
+		c.sanitizerEnabled = sanitizerEnabled
+		return nil
+	}
+}
+
 // Client is a wrapper holding HTTP client. It hold target server address and a version prefix,
 // and provides common features for building HTTP client wrappers.
 type Client struct {
@@ -108,6 +117,9 @@ type Client struct {
 	jar http.CookieJar
 	// newTracer creates new request tracer
 	newTracer NewTracer
+	// sanitizerEnabled will enable the input sanitizer which passes the URL
+	// path through a strict whitelist.
+	sanitizerEnabled bool
 }
 
 // NewClient returns a new instance of roundtrip.Client, or nil and error
@@ -158,6 +170,14 @@ func (c *Client) Endpoint(params ...string) string {
 // c.PostForm(c.Endpoint("users"), url.Values{"name": []string{"John"}})
 //
 func (c *Client) PostForm(endpoint string, vals url.Values, files ...File) (*Response, error) {
+	// If the sanitizer is enabled, make sure the requested path is safe.
+	if c.sanitizerEnabled {
+		err := isPathSafe(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return c.RoundTrip(func() (*http.Response, error) {
 		if len(files) == 0 {
 			req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(vals.Encode()))
@@ -206,6 +226,14 @@ func (c *Client) PostForm(endpoint string, vals url.Values, files ...File) (*Res
 // c.PostJSON(c.Endpoint("users"), map[string]string{"name": "alice@example.com"})
 //
 func (c *Client) PostJSON(endpoint string, data interface{}) (*Response, error) {
+	// If the sanitizer is enabled, make sure the requested path is safe.
+	if c.sanitizerEnabled {
+		err := isPathSafe(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	tracer := c.newTracer()
 	return tracer.Done(c.RoundTrip(func() (*http.Response, error) {
 		data, err := json.Marshal(data)
@@ -225,6 +253,14 @@ func (c *Client) PostJSON(endpoint string, data interface{}) (*Response, error) 
 // c.PutJSON(c.Endpoint("users"), map[string]string{"name": "alice@example.com"})
 //
 func (c *Client) PutJSON(endpoint string, data interface{}) (*Response, error) {
+	// If the sanitizer is enabled, make sure the requested path is safe.
+	if c.sanitizerEnabled {
+		err := isPathSafe(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	tracer := c.newTracer()
 	return tracer.Done(c.RoundTrip(func() (*http.Response, error) {
 		data, err := json.Marshal(data)
@@ -244,6 +280,14 @@ func (c *Client) PutJSON(endpoint string, data interface{}) (*Response, error) {
 // c.PatchJSON(c.Endpoint("users"), map[string]string{"name": "alice@example.com"})
 //
 func (c *Client) PatchJSON(endpoint string, data interface{}) (*Response, error) {
+	// If the sanitizer is enabled, make sure the requested path is safe.
+	if c.sanitizerEnabled {
+		err := isPathSafe(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	tracer := c.newTracer()
 	return tracer.Done(c.RoundTrip(func() (*http.Response, error) {
 		data, err := json.Marshal(data)
@@ -263,6 +307,14 @@ func (c *Client) PatchJSON(endpoint string, data interface{}) (*Response, error)
 // re, err := c.Delete(c.Endpoint("users", "id1"))
 //
 func (c *Client) Delete(endpoint string) (*Response, error) {
+	// If the sanitizer is enabled, make sure the requested path is safe.
+	if c.sanitizerEnabled {
+		err := isPathSafe(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	tracer := c.newTracer()
 	return tracer.Done(c.RoundTrip(func() (*http.Response, error) {
 		req, err := http.NewRequest(http.MethodDelete, endpoint, nil)
@@ -292,8 +344,16 @@ func (c *Client) DeleteWithParams(endpoint string, params url.Values) (*Response
 //
 // re, err := c.Get(c.Endpoint("users"), url.Values{"name": []string{"John"}})
 //
-func (c *Client) Get(u string, params url.Values) (*Response, error) {
-	baseUrl, err := url.Parse(u)
+func (c *Client) Get(endpoint string, params url.Values) (*Response, error) {
+	// If the sanitizer is enabled, make sure the requested path is safe.
+	if c.sanitizerEnabled {
+		err := isPathSafe(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	baseUrl, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -314,8 +374,16 @@ func (c *Client) Get(u string, params url.Values) (*Response, error) {
 //
 // f, err := c.GetFile("files", "report.txt") // returns "/v1/files/report.txt"
 //
-func (c *Client) GetFile(u string, params url.Values) (*FileResponse, error) {
-	baseUrl, err := url.Parse(u)
+func (c *Client) GetFile(endpoint string, params url.Values) (*FileResponse, error) {
+	// If the sanitizer is enabled, make sure the requested path is safe.
+	if c.sanitizerEnabled {
+		err := isPathSafe(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	baseUrl, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
 	}
@@ -349,13 +417,22 @@ type ReadSeekCloser interface {
 // OpenFile opens file using HTTP protocol and uses `Range` headers
 // to seek to various positions in the file, this means that server
 // has to support the flags `Range` and `Content-Range`
-func (c *Client) OpenFile(u string, params url.Values) (ReadSeekCloser, error) {
-	endpoint, err := url.Parse(u)
+func (c *Client) OpenFile(endpoint string, params url.Values) (ReadSeekCloser, error) {
+	// If the sanitizer is enabled, make sure the requested path is safe.
+	if c.sanitizerEnabled {
+		err := isPathSafe(endpoint)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	u, err := url.Parse(endpoint)
 	if err != nil {
 		return nil, err
 	}
-	endpoint.RawQuery = params.Encode()
-	return newSeeker(c, endpoint.String())
+	u.RawQuery = params.Encode()
+
+	return newSeeker(c, u.String())
 }
 
 // RoundTripFn inidicates any function that can be passed to RoundTrip

--- a/sanitize.go
+++ b/sanitize.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roundtrip
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// errorMessage is the error message to return when invalid input is provided by the caller.
+const errorMessage = "invalid path, path can only be composed of characters, hyphens, slashes, and dots"
+
+// whitelistPattern is the pattern of allowed characters for the path.
+var whitelistPattern = regexp.MustCompile(`^[0-9A-Za-z@/_:.-]*$`)
+
+// isPathSafe checks if the passed in path conforms to a whitelist.
+func isPathSafe(s string) error {
+	u, err := url.Parse(s)
+	if err != nil {
+		return err
+	}
+
+	e, err := url.PathUnescape(u.Path)
+	if err != nil {
+		return err
+	}
+
+	if strings.Contains(e, "..") {
+		return fmt.Errorf(errorMessage)
+	}
+
+	if !whitelistPattern.MatchString(e) {
+		return fmt.Errorf(errorMessage)
+	}
+
+	return nil
+}

--- a/sanitize_test.go
+++ b/sanitize_test.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2018 Gravitational, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package roundtrip
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"gopkg.in/check.v1"
+)
+
+func TestSanitizer(t *testing.T) { check.TestingT(t) }
+
+type SanitizeSuite struct {
+}
+
+var _ = check.Suite(&SanitizeSuite{})
+var _ = fmt.Printf
+
+func (s *SanitizeSuite) SetUpSuite(c *check.C) {
+}
+
+func (s *SanitizeSuite) TearDownSuite(c *check.C) {
+}
+
+func (s *SanitizeSuite) TearDownTest(c *check.C) {
+}
+
+func (s *SanitizeSuite) SetUpTest(c *check.C) {
+}
+
+func (s *SanitizeSuite) TestSanitizePath(c *check.C) {
+	tests := []struct {
+		inPath   string
+		outError bool
+	}{
+		{
+			inPath:   "http://example.com:3080/hello",
+			outError: false,
+		},
+		{
+			inPath:   "http://example.com:3080/hello/../world",
+			outError: true,
+		},
+		{
+			inPath:   fmt.Sprintf("http://localhost:3080/hello/%v/goodbye", url.PathEscape("..")),
+			outError: true,
+		},
+		{
+			inPath:   "http://example.com:3080/hello?foo=..",
+			outError: false,
+		},
+	}
+
+	for i, tt := range tests {
+		comment := check.Commentf("Test %v", i)
+
+		err := isPathSafe(tt.inPath)
+		if tt.outError {
+			c.Assert(err, check.NotNil, comment)
+		} else {
+			c.Assert(err, check.IsNil, comment)
+		}
+	}
+}


### PR DESCRIPTION
**Purpose**

URL paths can be subject to directory traversal attacks. This is normally not an issue as an attacker can simply access the other requested URL directly. However for situations where a public service crafts a request to a private service, this can be an issue potentially exposing private endpoints.

**Implementation**

To ensure this does not happen, a path sanitizer is used everywhere to make sure no paths contain path traversal attempts.