### PR TITLE
Add support for MIME header attributes in a multipart section.

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -276,10 +276,8 @@ func (s *ClientSuite) TestOpenFile(c *C) {
 	defer os.RemoveAll(file.Name())
 
 	now := time.Now().UTC()
-	var user, pass string
 	srv := serveHandler(func(w http.ResponseWriter, r *http.Request) {
-		var ok bool
-		user, pass, ok = r.BasicAuth()
+		_, _, ok := r.BasicAuth()
 		c.Assert(ok, Equals, true)
 		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename=%v`, file.Name()))
 		http.ServeContent(w, r, file.Name(), now, file)


### PR DESCRIPTION
This change is necessitated by the recent changes to clean up multipart
handling in the stdlib regarding filenames.
See https://github.com/golang/go/commit/784ef4c53135644d70f3476a4bd90010b9acff66 for reference.