### PR TITLE
Refactor duplicate code, add missing method/encoding combinations

### DIFF
--- a/client.go
+++ b/client.go
@@ -177,11 +177,10 @@ func (c *Client) submitForm(ctx context.Context, method string, endpoint string,
 
 	return c.RoundTrip(func() (*http.Response, error) {
 		if len(files) == 0 {
-			req, err := http.NewRequest(method, endpoint, strings.NewReader(vals.Encode()))
+			req, err := http.NewRequestWithContext(ctx, method, endpoint, strings.NewReader(vals.Encode()))
 			if err != nil {
 				return nil, err
 			}
-			req = req.WithContext(ctx)
 			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 			c.addAuth(req)
 			return c.client.Do(req)
@@ -208,11 +207,10 @@ func (c *Client) submitForm(ctx context.Context, method string, endpoint string,
 			return c.writeWithPipe(endpoint, vals, buffers...)
 		}
 
-		req, err := http.NewRequest(http.MethodPost, endpoint, &buf)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, &buf)
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
 		req.Header.Set("Content-Type",
 			fmt.Sprintf(`multipart/form-data;boundary="%v"`, writer.Boundary()))
 		c.addAuth(req)
@@ -256,11 +254,10 @@ func (c *Client) submitJSON(ctx context.Context, method string, endpoint string,
 	tracer := c.newTracer()
 	return tracer.Done(c.RoundTrip(func() (*http.Response, error) {
 		data, err := json.Marshal(data)
-		req, err := http.NewRequest(method, endpoint, bytes.NewBuffer(data))
+		req, err := http.NewRequestWithContext(ctx, method, endpoint, bytes.NewBuffer(data))
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
 		req.Header.Set("Content-Type", "application/json")
 		c.addAuth(req)
 		tracer.Start(req)
@@ -307,11 +304,10 @@ func (c *Client) Delete(ctx context.Context, endpoint string) (*Response, error)
 
 	tracer := c.newTracer()
 	return tracer.Done(c.RoundTrip(func() (*http.Response, error) {
-		req, err := http.NewRequest(http.MethodDelete, endpoint, nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodDelete, endpoint, nil)
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
 		c.addAuth(req)
 		tracer.Start(req)
 		return c.client.Do(req)
@@ -351,11 +347,10 @@ func (c *Client) Get(ctx context.Context, endpoint string, params url.Values) (*
 	baseUrl.RawQuery = params.Encode()
 	tracer := c.newTracer()
 	return tracer.Done(c.RoundTrip(func() (*http.Response, error) {
-		req, err := http.NewRequest(http.MethodGet, baseUrl.String(), nil)
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseUrl.String(), nil)
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
 		c.addAuth(req)
 		tracer.Start(req)
 		return c.client.Do(req)
@@ -380,11 +375,10 @@ func (c *Client) GetFile(ctx context.Context, endpoint string, params url.Values
 		return nil, err
 	}
 	baseUrl.RawQuery = params.Encode()
-	req, err := http.NewRequest(http.MethodGet, baseUrl.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseUrl.String(), nil)
 	if err != nil {
 		return nil, err
 	}
-	req = req.WithContext(ctx)
 	c.addAuth(req)
 	tracer := c.newTracer()
 	tracer.Start(req)

--- a/client.go
+++ b/client.go
@@ -166,7 +166,7 @@ func (c *Client) Endpoint(params ...string) string {
 	return fmt.Sprintf("%s/%s", c.addr, strings.Join(params, "/"))
 }
 
-func (c *Client) doForm(ctx context.Context, method string, endpoint string, vals url.Values, files []File) (*Response, error) {
+func (c *Client) submitForm(ctx context.Context, method string, endpoint string, vals url.Values, files []File) (*Response, error) {
 	// If the sanitizer is enabled, make sure the requested path is safe.
 	if c.sanitizerEnabled {
 		err := isPathSafe(endpoint)
@@ -225,7 +225,7 @@ func (c *Client) doForm(ctx context.Context, method string, endpoint string, val
 // c.PostForm(c.Endpoint("users"), url.Values{"name": []string{"John"}})
 //
 func (c *Client) PostForm(ctx context.Context, endpoint string, vals url.Values, files ...File) (*Response, error) {
-	return c.doForm(ctx, http.MethodPost, endpoint, vals, files)
+	return c.submitForm(ctx, http.MethodPost, endpoint, vals, files)
 }
 
 // PutForm puts urlencoded form with values and returns the result
@@ -233,7 +233,7 @@ func (c *Client) PostForm(ctx context.Context, endpoint string, vals url.Values,
 // c.PutForm(c.Endpoint("users"), url.Values{"name": []string{"John"}})
 //
 func (c *Client) PutForm(ctx context.Context, endpoint string, vals url.Values, files ...File) (*Response, error) {
-	return c.doForm(ctx, http.MethodPut, endpoint, vals, files)
+	return c.submitForm(ctx, http.MethodPut, endpoint, vals, files)
 }
 
 // PatchForm patches urlencoded form with values and returns the result
@@ -241,10 +241,10 @@ func (c *Client) PutForm(ctx context.Context, endpoint string, vals url.Values, 
 // c.PatchForm(c.Endpoint("users"), url.Values{"name": []string{"John"}})
 //
 func (c *Client) PatchForm(ctx context.Context, endpoint string, vals url.Values, files ...File) (*Response, error) {
-	return c.doForm(ctx, http.MethodPatch, endpoint, vals, files)
+	return c.submitForm(ctx, http.MethodPatch, endpoint, vals, files)
 }
 
-func (c *Client) doJSON(ctx context.Context, method string, endpoint string, data interface{}) (*Response, error) {
+func (c *Client) submitJSON(ctx context.Context, method string, endpoint string, data interface{}) (*Response, error) {
 	// If the sanitizer is enabled, make sure the requested path is safe.
 	if c.sanitizerEnabled {
 		err := isPathSafe(endpoint)
@@ -273,7 +273,7 @@ func (c *Client) doJSON(ctx context.Context, method string, endpoint string, dat
 // c.PostJSON(c.Endpoint("users"), map[string]string{"name": "alice@example.com"})
 //
 func (c *Client) PostJSON(ctx context.Context, endpoint string, data interface{}) (*Response, error) {
-	return c.doJSON(ctx, http.MethodPost, endpoint, data)
+	return c.submitJSON(ctx, http.MethodPost, endpoint, data)
 }
 
 // PutJSON posts JSON "application/json" encoded request body and "PUT" method
@@ -281,7 +281,7 @@ func (c *Client) PostJSON(ctx context.Context, endpoint string, data interface{}
 // c.PutJSON(c.Endpoint("users"), map[string]string{"name": "alice@example.com"})
 //
 func (c *Client) PutJSON(ctx context.Context, endpoint string, data interface{}) (*Response, error) {
-	return c.doJSON(ctx, http.MethodPut, endpoint, data)
+	return c.submitJSON(ctx, http.MethodPut, endpoint, data)
 }
 
 // PatchJSON posts JSON "application/json" encoded request body and "PATCH" method
@@ -289,7 +289,7 @@ func (c *Client) PutJSON(ctx context.Context, endpoint string, data interface{})
 // c.PatchJSON(c.Endpoint("users"), map[string]string{"name": "alice@example.com"})
 //
 func (c *Client) PatchJSON(ctx context.Context, endpoint string, data interface{}) (*Response, error) {
-	return c.doJSON(ctx, http.MethodPatch, endpoint, data)
+	return c.submitJSON(ctx, http.MethodPatch, endpoint, data)
 }
 
 // Delete executes DELETE request to the endpoint with no body

--- a/client.go
+++ b/client.go
@@ -224,11 +224,7 @@ func (c *Client) PostForm(ctx context.Context, endpoint string, vals url.Values,
 	})
 }
 
-// PostJSON posts JSON "application/json" encoded request body
-//
-// c.PostJSON(c.Endpoint("users"), map[string]string{"name": "alice@example.com"})
-//
-func (c *Client) PostJSON(ctx context.Context, endpoint string, data interface{}) (*Response, error) {
+func (c *Client) doJSON(ctx context.Context, method string, endpoint string, data interface{}) (*Response, error) {
 	// If the sanitizer is enabled, make sure the requested path is safe.
 	if c.sanitizerEnabled {
 		err := isPathSafe(endpoint)
@@ -240,7 +236,7 @@ func (c *Client) PostJSON(ctx context.Context, endpoint string, data interface{}
 	tracer := c.newTracer()
 	return tracer.Done(c.RoundTrip(func() (*http.Response, error) {
 		data, err := json.Marshal(data)
-		req, err := http.NewRequest(http.MethodPost, endpoint, bytes.NewBuffer(data))
+		req, err := http.NewRequest(method, endpoint, bytes.NewBuffer(data))
 		if err != nil {
 			return nil, err
 		}
@@ -250,6 +246,14 @@ func (c *Client) PostJSON(ctx context.Context, endpoint string, data interface{}
 		tracer.Start(req)
 		return c.client.Do(req)
 	}))
+}
+
+// PostJSON posts JSON "application/json" encoded request body
+//
+// c.PostJSON(c.Endpoint("users"), map[string]string{"name": "alice@example.com"})
+//
+func (c *Client) PostJSON(ctx context.Context, endpoint string, data interface{}) (*Response, error) {
+	return c.doJSON(ctx, http.MethodPost, endpoint, data)
 }
 
 // PutJSON posts JSON "application/json" encoded request body and "PUT" method
@@ -257,27 +261,7 @@ func (c *Client) PostJSON(ctx context.Context, endpoint string, data interface{}
 // c.PutJSON(c.Endpoint("users"), map[string]string{"name": "alice@example.com"})
 //
 func (c *Client) PutJSON(ctx context.Context, endpoint string, data interface{}) (*Response, error) {
-	// If the sanitizer is enabled, make sure the requested path is safe.
-	if c.sanitizerEnabled {
-		err := isPathSafe(endpoint)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	tracer := c.newTracer()
-	return tracer.Done(c.RoundTrip(func() (*http.Response, error) {
-		data, err := json.Marshal(data)
-		req, err := http.NewRequest(http.MethodPut, endpoint, bytes.NewBuffer(data))
-		if err != nil {
-			return nil, err
-		}
-		req = req.WithContext(ctx)
-		req.Header.Set("Content-Type", "application/json")
-		c.addAuth(req)
-		tracer.Start(req)
-		return c.client.Do(req)
-	}))
+	return c.doJSON(ctx, http.MethodPut, endpoint, data)
 }
 
 // PatchJSON posts JSON "application/json" encoded request body and "PATCH" method
@@ -285,27 +269,7 @@ func (c *Client) PutJSON(ctx context.Context, endpoint string, data interface{})
 // c.PatchJSON(c.Endpoint("users"), map[string]string{"name": "alice@example.com"})
 //
 func (c *Client) PatchJSON(ctx context.Context, endpoint string, data interface{}) (*Response, error) {
-	// If the sanitizer is enabled, make sure the requested path is safe.
-	if c.sanitizerEnabled {
-		err := isPathSafe(endpoint)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	tracer := c.newTracer()
-	return tracer.Done(c.RoundTrip(func() (*http.Response, error) {
-		data, err := json.Marshal(data)
-		req, err := http.NewRequest(http.MethodPatch, endpoint, bytes.NewBuffer(data))
-		if err != nil {
-			return nil, err
-		}
-		req = req.WithContext(ctx)
-		req.Header.Set("Content-Type", "application/json")
-		c.addAuth(req)
-		tracer.Start(req)
-		return c.client.Do(req)
-	}))
+	return c.doJSON(ctx, http.MethodPatch, endpoint, data)
 }
 
 // Delete executes DELETE request to the endpoint with no body

--- a/client.go
+++ b/client.go
@@ -166,11 +166,7 @@ func (c *Client) Endpoint(params ...string) string {
 	return fmt.Sprintf("%s/%s", c.addr, strings.Join(params, "/"))
 }
 
-// PostForm posts urlencoded form with values and returns the result
-//
-// c.PostForm(c.Endpoint("users"), url.Values{"name": []string{"John"}})
-//
-func (c *Client) PostForm(ctx context.Context, endpoint string, vals url.Values, files ...File) (*Response, error) {
+func (c *Client) doForm(ctx context.Context, method string, endpoint string, vals url.Values, files []File) (*Response, error) {
 	// If the sanitizer is enabled, make sure the requested path is safe.
 	if c.sanitizerEnabled {
 		err := isPathSafe(endpoint)
@@ -181,7 +177,7 @@ func (c *Client) PostForm(ctx context.Context, endpoint string, vals url.Values,
 
 	return c.RoundTrip(func() (*http.Response, error) {
 		if len(files) == 0 {
-			req, err := http.NewRequest(http.MethodPost, endpoint, strings.NewReader(vals.Encode()))
+			req, err := http.NewRequest(method, endpoint, strings.NewReader(vals.Encode()))
 			if err != nil {
 				return nil, err
 			}
@@ -222,6 +218,30 @@ func (c *Client) PostForm(ctx context.Context, endpoint string, vals url.Values,
 		c.addAuth(req)
 		return c.client.Do(req)
 	})
+}
+
+// PostForm posts urlencoded form with values and returns the result
+//
+// c.PostForm(c.Endpoint("users"), url.Values{"name": []string{"John"}})
+//
+func (c *Client) PostForm(ctx context.Context, endpoint string, vals url.Values, files ...File) (*Response, error) {
+	return c.doForm(ctx, http.MethodPost, endpoint, vals, files)
+}
+
+// PutForm puts urlencoded form with values and returns the result
+//
+// c.PutForm(c.Endpoint("users"), url.Values{"name": []string{"John"}})
+//
+func (c *Client) PutForm(ctx context.Context, endpoint string, vals url.Values, files ...File) (*Response, error) {
+	return c.doForm(ctx, http.MethodPut, endpoint, vals, files)
+}
+
+// PatchForm patches urlencoded form with values and returns the result
+//
+// c.PatchForm(c.Endpoint("users"), url.Values{"name": []string{"John"}})
+//
+func (c *Client) PatchForm(ctx context.Context, endpoint string, vals url.Values, files ...File) (*Response, error) {
+	return c.doForm(ctx, http.MethodPatch, endpoint, vals, files)
 }
 
 func (c *Client) doJSON(ctx context.Context, method string, endpoint string, data interface{}) (*Response, error) {

--- a/client_test.go
+++ b/client_test.go
@@ -46,7 +46,7 @@ type ClientSuite struct {
 
 var _ = Suite(&ClientSuite{})
 
-func (s *ClientSuite) TestPostForm(c *C) {
+func (s *ClientSuite) TestPostPutPatchForm(c *C) {
 	var u *url.URL
 	var form url.Values
 	var method string
@@ -64,14 +64,34 @@ func (s *ClientSuite) TestPostForm(c *C) {
 	defer srv.Close()
 
 	clt := newC(srv.URL, "v1", BasicAuth("user", "pass"))
+
 	values := url.Values{"a": []string{"b"}}
 	out, err := clt.PostForm(context.Background(), clt.Endpoint("a", "b"), values)
-
 	c.Assert(err, IsNil)
 	c.Assert(string(out.Bytes()), Equals, "hello back")
 	c.Assert(u.String(), DeepEquals, "/v1/a/b")
 	c.Assert(form, DeepEquals, values)
 	c.Assert(method, Equals, http.MethodPost)
+	c.Assert(user, DeepEquals, "user")
+	c.Assert(pass, DeepEquals, "pass")
+
+	values = url.Values{"a": []string{"b put"}}
+	out, err = clt.PutForm(context.Background(), clt.Endpoint("a", "b"), values)
+	c.Assert(err, IsNil)
+	c.Assert(string(out.Bytes()), Equals, "hello back")
+	c.Assert(u.String(), DeepEquals, "/v1/a/b")
+	c.Assert(form, DeepEquals, values)
+	c.Assert(method, Equals, http.MethodPut)
+	c.Assert(user, DeepEquals, "user")
+	c.Assert(pass, DeepEquals, "pass")
+
+	values = url.Values{"a": []string{"b patch"}}
+	out, err = clt.PatchForm(context.Background(), clt.Endpoint("a", "b"), values)
+	c.Assert(err, IsNil)
+	c.Assert(string(out.Bytes()), Equals, "hello back")
+	c.Assert(u.String(), DeepEquals, "/v1/a/b")
+	c.Assert(form, DeepEquals, values)
+	c.Assert(method, Equals, http.MethodPatch)
 	c.Assert(user, DeepEquals, "user")
 	c.Assert(pass, DeepEquals, "pass")
 }

--- a/seeker.go
+++ b/seeker.go
@@ -65,11 +65,10 @@ func (s *seeker) canSeek() error {
 
 func newSeeker(c *Client, ctx context.Context, endpoint string) (ReadSeekCloser, error) {
 	response, err := c.RoundTrip(func() (*http.Response, error) {
-		req, err := http.NewRequest("HEAD", endpoint, nil)
+		req, err := http.NewRequestWithContext(ctx, "HEAD", endpoint, nil)
 		if err != nil {
 			return nil, err
 		}
-		req = req.WithContext(ctx)
 		c.addAuth(req)
 		return c.client.Do(req)
 	})


### PR DESCRIPTION
Added a `PatchForm` method due to a use-case in cloud, and `PutForm` just for completeness' sake. Also took the liberty to factor out the common parts of form & json submission methods.